### PR TITLE
disable buildkit in studio, remove version pin

### DIFF
--- a/sagemaker_studio_docker_cli_install/README.md
+++ b/sagemaker_studio_docker_cli_install/README.md
@@ -1,16 +1,25 @@
 The instructions to install Docker CLI and Docker Compose plugin based on SageMaker Studio Environment are documented below. Follow specific instructions based on applicable [Studio Application Type](https://docs.aws.amazon.com/sagemaker/latest/dg/machine-learning-environments.html) / [Images](https://docs.aws.amazon.com/sagemaker/latest/dg/notebooks-available-images.html#notebooks-available-images-supported). These instructions adhere to [Studio platforms requirements](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-local.html#studio-updated-local-docker) for enabling Local Mode/Docker Access.
 
+
 * [**SageMaker Distribution Docker CLI Install Directions**](sagemaker-distribution-docker-cli-install.sh):  This script provides instructions for Docker CLI Install in Studio JupyterLab/Studio Code Editor and Studio Classic [SageMaker Distribution Images](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-distribution.html) which are Ubuntu-Jammy based. Do `cat /etc/os-release` to verify the OS in App Image terminal.
   * Applicable Studio AppType/Images:
     * JupyterLab
     * Code Editor
     * Amazon SageMaker Studio Classic [Kernel Gateway Applications]
-      * Applicable Images: SageMaker Distribution v0 CPU, SageMaker Distribution v0 GPU, SageMaker Distribution v1 CPU, SageMaker Distribution v1 GPU.
+      * Applicable Images: SageMaker Distribution.
+* [**SageMaker Classic - Ubuntu-Jammy Docker CLI Install Directions**](sagemaker-ubuntu-jammy-docker-cli-install.sh):  This script provides instructions for Docker CLI Install for Studio Classic SageMaker Images which are Ubuntu-Jammy based. Do `cat /etc/os-release` to verify the OS in App Image terminal.
+  * Applicable Studio AppTypes/Images:
+    * Amazon SageMaker Studio Classic [Kernel Gateway Applications]
+      * Applicable Images: Data Science, SparkAnalytics.
 * [**SageMaker Classic - Debian-Bullseye Docker CLI Install Directions**](sagemaker-debian-bullseye-cli-install.sh):  This script provides instructions for Docker CLI Install for Studio Classic SageMaker Images which are Debian-Bullseye based. Do `cat /etc/os-release` to verify the OS in App Image terminal.
   * Applicable Studio AppTypes/Images:
     * Amazon SageMaker Studio Classic [Kernel Gateway Applications]
-      * Applicable Images: Base Python 3.0, Base Python 2.0, Data Science 3.0, Data Science 2.0, SparkAnalytics 2.0, SparkAnalytics 1.0.
+      * Applicable Images: Base Python.
 * [**SageMaker Classic - Ubuntu-Focal Docker CLI Install Directions**](sagemaker-ubuntu-focal-docker-cli-install.sh):  This script provides instructions for Docker CLI Install for Studio Classic SageMaker Images which are Ubuntu-Focal based. Do `cat /etc/os-release` to verify the OS in App Image terminal.
   * Applicable Studio AppTypes/Images:
     * Amazon SageMaker Studio Classic [Kernel Gateway Applications]
       * Applicable Images: All currently supported Pytorch/Tensorflow Framework based Studio Images [here](https://docs.aws.amazon.com/sagemaker/latest/dg/notebooks-available-images.html#notebooks-available-images-supported).
+
+<div style="background-color: #ffffcc; border-left: 6px solid #ffeb3b; margin-bottom: 15px; padding: 4px 12px;">
+  <p style="color: #000000; margin: 0;"><strong>Note:</strong> For Studio use-cases requiring Docker Build Feature, Docker's Buildkit support should be disabled. Disable using: `export DOCKER_BUILDKIT=0`. This feature is not allowed in Studio as it requires privileged mode execution. </p>
+</div>

--- a/sagemaker_studio_docker_cli_install/sagemaker-debian-bullseye-cli-install.sh
+++ b/sagemaker_studio_docker_cli_install/sagemaker-debian-bullseye-cli-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-apt-get update
+apt-get update -y
 apt-get install ca-certificates curl
 install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
@@ -9,12 +9,18 @@ echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
   $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
   tee /etc/apt/sources.list.d/docker.list > /dev/null
-apt-get update
+apt-get update -y
 
-# pick the latest patch from:
-# apt-cache madison docker-ce | awk '{ print $3 }' | grep -i 20.10
-VERSION_STRING=5:20.10.24~3-0~debian-bullseye
-apt-get install docker-ce-cli=$VERSION_STRING docker-compose-plugin -y
+# install docker cli and docker compose plugin
+apt-get install docker-ce-cli docker-compose-plugin -y
+
+# disabling docker build kit, docker's build kit feature is not allowed in Studio
+export DOCKER_BUILDKIT=0
+
+# validate the Docker Client is able to access Docker Server at [unix:///docker/proxy.sock]
+if [ -z "${DOCKER_HOST}" ]; then
+  export DOCKER_HOST="unix:///docker/proxy.sock"
+fi
 
 # validate the Docker Client is able to access Docker Server at [unix:///docker/proxy.sock]
 docker version

--- a/sagemaker_studio_docker_cli_install/sagemaker-distribution-docker-cli-install.sh
+++ b/sagemaker_studio_docker_cli_install/sagemaker-distribution-docker-cli-install.sh
@@ -11,10 +11,16 @@ echo \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get -y update
 
-# pick the latest patch from:
-# apt-cache madison docker-ce | awk '{ print $3 }' | grep -i 20.10
-VERSION_STRING=5:20.10.24~3-0~ubuntu-jammy
-sudo apt-get install docker-ce-cli=$VERSION_STRING docker-compose-plugin -y
+# install docker cli and docker compose plugin
+sudo apt-get install docker-ce-cli docker-compose-plugin -y
+
+# disabling docker build kit, docker's build kit feature is not allowed in Studio
+export DOCKER_BUILDKIT=0
+
+# validate the Docker Client is able to access Docker Server at [unix:///docker/proxy.sock]
+if [ -z "${DOCKER_HOST}" ]; then
+  export DOCKER_HOST="unix:///docker/proxy.sock"
+fi
 
 # validate the Docker Client is able to access Docker Server at [unix:///docker/proxy.sock]
 docker version

--- a/sagemaker_studio_docker_cli_install/sagemaker-ubuntu-focal-docker-cli-install.sh
+++ b/sagemaker_studio_docker_cli_install/sagemaker-ubuntu-focal-docker-cli-install.sh
@@ -13,10 +13,16 @@ echo \
 
 apt-get update
 
-# pick the latest patch from:
-# apt-cache madison docker-ce | awk '{ print $3 }' | grep -i 20.10
-VERSION_STRING=5:20.10.24~3-0~ubuntu-focal
-apt-get install docker-ce-cli=$VERSION_STRING docker-compose-plugin -y
+# install docker cli and docker compose plugin
+apt-get install docker-ce-cli docker-compose-plugin -y
+
+# disabling docker build kit, docker's build kit feature is not allowed in Studio
+export DOCKER_BUILDKIT=0
+
+# validate the Docker Client is able to access Docker Server at [unix:///docker/proxy.sock]
+if [ -z "${DOCKER_HOST}" ]; then
+  export DOCKER_HOST="unix:///docker/proxy.sock"
+fi
 
 # validate the Docker Client is able to access Docker Server at [unix:///docker/proxy.sock]
 docker version

--- a/sagemaker_studio_docker_cli_install/sagemaker-ubuntu-jammy-docker-cli-install.sh
+++ b/sagemaker_studio_docker_cli_install/sagemaker-ubuntu-jammy-docker-cli-install.sh
@@ -19,13 +19,13 @@ echo \
 
 apt-get update
 
-# pick the latest patch from:
-# apt-cache madison docker-ce | awk '{ print $3 }' | grep -i 20.10
-VERSION_STRING=5:20.10.24~3-0~ubuntu-${VERSION_CODENAME:-jammy}
-apt-get install docker-ce-cli=$VERSION_STRING docker-compose-plugin -y
+# install docker cli and docker compose plugin
+apt-get install docker-ce-cli docker-compose-plugin -y
+
+# disabling docker build kit, docker's build kit feature is not allowed in Studio
+export DOCKER_BUILDKIT=0
 
 # validate the Docker Client is able to access Docker Server at [unix:///docker/proxy.sock]
-
 if [ -z "${DOCKER_HOST}" ]; then
   export DOCKER_HOST="unix:///docker/proxy.sock"
 fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Help announce to users of LCC script to explicitly disable docker's buildkit post CLI install. This is a required step to use Docker Build functionality in Studio.
Additionally we also remove the version pin for docker cli.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
